### PR TITLE
Create a 404.html page with a goofy message

### DIFF
--- a/themes/pehtheme-hugo/layouts/404.html
+++ b/themes/pehtheme-hugo/layouts/404.html
@@ -1,0 +1,38 @@
+{{ define "main" }}
+{{- partial "content/breadcrumb.html" . -}}
+
+<div class="grid grid-cols-1 md:grid-cols-3 gap-6 mb-14">
+
+  <article class="md:col-span-2 prose lg:prose-lg">
+
+    <header class="not-prose">
+      
+      <h1 id="title" class="text-4xl font-bold leading-normal">We're sorry, that page wasn't found!</h1>
+
+      <div id="lead" class="my-6">
+
+        <p class="font-bold">Our team of qualified engineers is currently playing board games, but we'll be happy to help you locate the page if you create a github issue or let us know about it during board game night. </p>
+
+      </div>
+      
+      <div id="writer" class="flex items-center space-x-4">
+      
+    </header>
+
+    
+    <div id="content" class="mb-14">
+    
+    </div>
+
+  </article>
+
+  <!-- Aside -->
+  <aside class="md:col-span-1">
+
+    {{- partial "content/aside.html" . -}}
+    
+  </aside>
+
+</div>
+  
+{{ end }}


### PR DESCRIPTION
According to the documentation, the 404.html layout page may need to be configured on the server itself. 
https://gohugo.io/templates/404/ 

When a page is not found on localhost, the contents of the 404.html seems to show up automatically when running on my machine. 

Also, the message in this 404 is pretty silly and mentions coming to board game night and/or submitting a github issue - changing anything about this page would be very simple.