### PR TITLE
Replace spaces with hyphens for view all link 

### DIFF
--- a/themes/pehtheme-hugo/layouts/_default/home.html
+++ b/themes/pehtheme-hugo/layouts/_default/home.html
@@ -34,8 +34,8 @@
       <h2 class="text-3xl md:text-4xl font-bold mr-auto">{{ $cat | humanize }}</h2>
 
       {{ $category := printf "/categories/%s" $cat }}
-      {{ $categoryWithFixedSpaces := replace $category " " "-" }}
-      <a class="border rounded-full py-2 px-4 md:px-6 hover:bg-blue-100" href="{{ $categoryWithFixedSpaces | absURL }} ">View All</a>
+      {{ $categoryWithHyphens := replace $category " " "-" }}
+      <a class="border rounded-full py-2 px-4 md:px-6 hover:bg-blue-100" href="{{ $categoryWithHyphens | absURL }} ">View All</a>
     </div>
 
     <div class="grid grid-cols-1 md:grid-cols-3 gap-x-6 gap-y-10">

--- a/themes/pehtheme-hugo/layouts/_default/home.html
+++ b/themes/pehtheme-hugo/layouts/_default/home.html
@@ -33,7 +33,9 @@
 
       <h2 class="text-3xl md:text-4xl font-bold mr-auto">{{ $cat | humanize }}</h2>
 
-      <a class="border rounded-full py-2 px-4 md:px-6 hover:bg-blue-100" href="{{ printf "/categories/%s" $cat | absURL }}">View All</a>
+      {{ $category := printf "/categories/%s" $cat }}
+      {{ $categoryWithFixedSpaces := replace $category " " "-" }}
+      <a class="border rounded-full py-2 px-4 md:px-6 hover:bg-blue-100" href="{{ $categoryWithFixedSpaces | absURL }} ">View All</a>
     </div>
 
     <div class="grid grid-cols-1 md:grid-cols-3 gap-x-6 gap-y-10">


### PR DESCRIPTION
It looks like the URL for a category needs to have hyphens when there are multiple words. 

Replacing each space with a with a hyphen in a URL is a hack to get the category page to show up when the category is multiple words. If this has to be done a bunch of times it could get messy, but it just seems to be the view all button for now. 

As the site sits right now, this won't actually fix anything since there aren't any multi-word categories, but figured that I'd share the hack anyway. 