### PR TITLE
Update category 'boardgames' to be 'board games' instead

### DIFF
--- a/content/posts/2024/05-05__First_post.md
+++ b/content/posts/2024/05-05__First_post.md
@@ -5,7 +5,7 @@ slug: /welcome/
 description: Welcome to the Canton Tabletop Gamers site
 image: images/catan-close-up.png
 categories:
-  - boardgames
+  - board games
   - announcements
 draft: false
 ---

--- a/hugo.toml
+++ b/hugo.toml
@@ -12,7 +12,7 @@ summaryLength = '20' # <- 20 words are approximately 160 characters
     # Meta description, not exceeding 160 characters, used for the meta description within the HTML head
     description = 'Canton Tabletop Gamers: Board gaming group in Canton, Ohio, USA'
     mainSections = 'posts'
-    mainCategory = 'boardgames'
+    mainCategory = 'board games'
     comments = false
 
 [author]


### PR DESCRIPTION
Now that the "View all" button is updated on the home page to allow for multi-word categories, the spelling of the boardgames category should be able to be updated to board games